### PR TITLE
General improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,24 +38,29 @@ use {
 ```
 
 # Configuration
-Here are the default settings used in Scretch
+
+Here are the default settings used in Scretch:
 ```lua
 local config = {
     scretch_dir = vim.fn.stdpath('config') .. '/plugin/scretch/', -- will be created if it doesn't exist
     default_name = "scretch_",
     default_type = "txt", -- default unnamed Scretches are named "scretch_*.txt"
     split_cmd = "vsplit", -- vim split command used when creating a new Scretch
-    mappings = {
-        new = "<leader>sn", -- creates a new unnamed scretch
-        new_named = "<leader>snn", -- prompts you with a name to create a named scretch (you have to provide the extension)
-        last = "<leader>sl", -- toggles a split with the last scretch opened
-        search = "<leader>ss", -- performs a fuzzy find accross Scretch directory
-        grep = "<leader>sg", -- live greps accross Scretch directory
-        explore = "<leader>sv", -- opens explorer for easy file mgmt in Scretch directory
-    },
 }
 ```
 You can copy those settings, update them with your preferences and put them into the setup function to load them.
+
+## Suggested mappings
+
+```lua
+local scretch = require("scretch")
+vim.keymap.set('n', '<leader>sn', scretch.new)
+vim.keymap.set('n', '<leader>snn', scretch.new_named)
+vim.keymap.set('n', '<leader>sl', scretch.last)
+vim.keymap.set('n', '<leader>ss', scretch.search)
+vim.keymap.set('n', '<leader>sg', scretch.grep)
+vim.keymap.set('n', '<leader>sv', scretch.explore)
+```
 
 # Issues
 

--- a/lua/scretch/init.lua
+++ b/lua/scretch/init.lua
@@ -69,7 +69,7 @@ end
 
 -- opens the explorer in the scretch directory
 local function explore()
-    api.nvim_command("Ex " .. config.scretch_dir)
+    api.nvim_command("edit " .. config.scretch_dir)
 end
 
 -- returns the path of the most recently modified file in the given directory.

--- a/lua/scretch/init.lua
+++ b/lua/scretch/init.lua
@@ -50,10 +50,16 @@ end
 
 -- performs a fuzzy find accross scretch files
 local function search()
+    local find_command = {}
+    if vim.fn.executable("rg") == 1 then
+        find_command = { 'rg', '--files', '--hidden', '-g', '*' }
+    else
+        find_command = { 'find', '.', '-type', 'f', '-not', '-path', '"./git/*"' }
+    end
     require('telescope.builtin').find_files({
         prompt_title = "Scretch Files",
         cwd = config.scretch_dir,
-        find_command = { 'rg', '--files', '--hidden', '-g', '*' },
+        find_command = find_command,
     })
 end
 

--- a/lua/scretch/init.lua
+++ b/lua/scretch/init.lua
@@ -1,7 +1,7 @@
 local api = vim.api
 
 local config = {
-    scretch_dir = vim.fn.stdpath('config') .. '/plugin/.scretch/',
+    scretch_dir = vim.fn.stdpath('config') .. '/scretch/',
     default_name = "scretch_",
     default_type = "txt",
     split_cmd = "vsplit",

--- a/lua/scretch/init.lua
+++ b/lua/scretch/init.lua
@@ -5,26 +5,12 @@ local config = {
     default_name = "scretch_",
     default_type = "txt",
     split_cmd = "vsplit",
-    mappings = {
-        new = "<leader>sn",
-        new_named = "<leader>snn",
-        last = "<leader>sl",
-        search = "<leader>ss",
-        grep = "<leader>sg",
-        explore = "<leader>sv",
-    },
 }
 
 local function setup(user_config)
     config = vim.tbl_deep_extend("keep", config, user_config or {})
     vim.fn.mkdir(config.scretch_dir, "p")
-    -- Enregistre les mappings
-    for action, mapping in pairs(config.mappings) do
-        vim.api.nvim_set_keymap("n", mapping, string.format("<cmd>Scretch %s<CR>", action),
-            { noremap = true, silent = true })
-    end
 end
-
 
 -- creates a new scretch file in the scretch directory.
 local function new()


### PR DESCRIPTION
The following PR does:
* add fallback search command if `rg` is not installed,
* using `edit` instead of `Ex` because this will also work with other directories listing plugins
* moving default stretch location from `~/.config/nvim/plugin/.scretch` to `~/.config/nvim/scretch`. The plugin directory in neovim is meant for storing files that you want to load at vim startup and not for arbitrary files for this reason I think is more sensible to use is own directory
* don't remap keybindings for the user since this could lead to binding clashes with user setup, instead suggest preferable binding in the README

Congrats for making the switch to neovim, you will not regret it! This PR is more a general improvements for making the plugin behave more consistently in the plugin ecosystem.