### PR TITLE
feat: allow for use of fzf-lua instad of telescope

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://user-images.githubusercontent.com/49813786/235376626-6b23bf7e-def1-4d4b-
 
 # Installation
 
-This plugin requires Telescope and ripgrep to function.
+This plugin requires Telescope or fzf-lua and ripgrep to function.
 
 If you don't have ripgrep installed, I recommend you go check the installation procedure [here](https://github.com/BurntSushi/ripgrep#installation).
 If you don't want to install it, it should fall back to `find`.
@@ -28,6 +28,8 @@ You can paste the following code using Packer, or adapt to your favorite package
 use {
   "Sonicfury/scretch.nvim",
   requires = 'nvim-telescope/telescope.nvim',
+  -- or
+  -- requires = 'ibhagwan/fzf-lua' ,
   config = function()
     require("scretch").setup {
       -- your configuration comes here
@@ -47,6 +49,7 @@ local config = {
     default_name = "scretch_",
     default_type = "txt", -- default unnamed Scretches are named "scretch_*.txt"
     split_cmd = "vsplit", -- vim split command used when creating a new Scretch
+    backend = "telescope.builtin" -- also accpets "fzf-lua"
 }
 ```
 You can copy those settings, update them with your preferences and put them into the setup function to load them.

--- a/lua/scretch/init.lua
+++ b/lua/scretch/init.lua
@@ -34,9 +34,10 @@ local function new_named()
     api.nvim_command(config.split_cmd .. ' ' .. scretch_name)
 end
 
-local function get_search_args(backend)
+-- performs a fuzzy find across scretch files
+local function search()
     local default_args = { cwd = config.scretch_dir }
-    if backend == "telescope.builtin" then
+    if config.backend == "telescope.builtin" then
         local find_command
 
         if vim.fn.executable("rg") == 1 then
@@ -49,36 +50,31 @@ local function get_search_args(backend)
             prompt_title = "Scretch Files",
             find_command = find_command,
         }))
-    elseif backend == "fzf-lua" then
+    elseif config.backend == "fzf-lua" then
         return require('fzf-lua').files(vim.tbl_deep_extend("force", default_args,{
             prompt = "Scretch Files> ",
         }))
     end
 end
 
--- performs a fuzzy find across scretch files
-local function search()
-    get_search_args(config.backend)
+local function get_grep_args(backend, query)
+    
 end
 
-local function get_grep_args(backend, query)
+-- performs a live grep accross scretch files
+local function grep(query)
     local default_args = { cwd = config.scretch_dir }
-    if backend == "telescope.builtin" then
+    if config.backend == "telescope.builtin" then
         return require('telescope.builtin').live_grep(vim.tbl_deep_extend("force", default_args,{
             prompt_title = "Scretch Search",
             search_dirs = { config.scretch_dir },
             live_grep_args = { '--hidden', '-g', '*', query },
         }))
-    elseif backend == "fzf-lua" then
+    elseif config.backend == "fzf-lua" then
         return require("fzf-lua").live_grep(vim.tbl_deep_extend("force", default_args,{
             prompt = "Scretch Search>",
         }))
     end
-end
-
--- performs a live grep accross scretch files
-local function grep(query)
-    get_grep_args(config.backend, query)
 end
 
 -- opens the explorer in the scretch directory


### PR DESCRIPTION
This PR allows for the user to input a `backend` param to the config. It defaults to `"telescope.builtin"` and keeps in inital implementation.

If the user passes `"fzf-lua"` as an argumen to the `backend` param, this will be used instead of telescope.
